### PR TITLE
use var instead of let

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,7 +53,7 @@ const sourceFile = {
 function readData(path) {
   return new Promise((resolve, reject) => {
     fs.readFile(path, 'utf8', (error, raw) => {
-      let json
+    var json = {};
 
       if (error) {
         return reject(`Can't read file "${path}"\n${error}`)
@@ -89,8 +89,8 @@ if (argv.source) {
 }
 else {
   console.log('searching for the training examples...')
-  let isSearchingOver = false
-  let inReading = 0
+  var isSearchingOver = false;
+  var inReading = 0;
 
   function checkDone() {
     if (isSearchingOver && inReading === 0) {
@@ -105,7 +105,7 @@ else {
 
   const finder = findit(process.cwd())
   finder.on('directory', function (dir, stat, stop) {
-    var base = path.basename(dir)
+    var base = path.basename(dir);
     if (base === '.git' || base === 'node_modules') stop()
   })
 


### PR DESCRIPTION
This failed out of the box for me with node v4.2.6, apparently because `let` is not supported.  (Unrelated: I didn't have a `node` command, but I made a symlink from `node` to `nodejs`)