### PR TITLE
Fix PropTypes error in ExampleEditor

### DIFF
--- a/src/components/ExampleEditor.js
+++ b/src/components/ExampleEditor.js
@@ -31,14 +31,16 @@ class ExampleEditor extends Component {
 }
 
 ExampleEditor.propTypes = {
-  text: PropTypes.string.isRequired,
-  intent: PropTypes.string.isRequired,
-  entities: PropTypes.arrayOf(PropTypes.shape({
-    start: PropTypes.number.isRequired,
-    end: PropTypes.number.isRequired,
-    value: PropTypes.string.isRequired,
-    entity: PropTypes.string.isRequired,
-  })),
+  example: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    intent: PropTypes.string.isRequired,
+    entities: PropTypes.arrayOf(PropTypes.shape({
+      start: PropTypes.number.isRequired,
+      end: PropTypes.number.isRequired,
+      value: PropTypes.string.isRequired,
+      entity: PropTypes.string.isRequired,
+    })),
+  })
 }
 
 export default connect(null, mapActions)(ExampleEditor)


### PR DESCRIPTION
Need to name the object being shaped as 'example' to prevent 'failed prop type' errors (see below)

```
> Warning: Failed prop type: The prop `text` is marked as required in `ExampleEditor`, but its value is `undefined`.
> Warning: Failed prop type: The prop `intent` is marked as required in `ExampleEditor`, but its value is `undefined
```