### PR TITLE
Trim whitespace before export/on save

### DIFF
--- a/src/utils/generateExport.js
+++ b/src/utils/generateExport.js
@@ -1,13 +1,29 @@
 import store from '../state/store'
 import immutable from 'object-path-immutable'
 
+function trimWhitespace(text, entities) {
+  return entities.map((entity) => {
+    let entityText = text.substring(entity.start, entity.end).trim()
+    let entityPos = text.indexOf(entityText)
+    return {
+      start: entityPos,
+      end: entityPos + entityText.length,
+      value: entity.value,
+      entity: entity.entity
+    }
+  })
+}
+
 export default function () {
   const state = store.getState()
   const source = immutable.set(
     state.originalSource,
     'rasa_nlu_data.common_examples',
     state.examples.map(
-      ({text, intent, entities}) => ({text, intent, entities})
+      ({text, intent, entities}) => {
+        entities = trimWhitespace(text, entities)
+        return ({text, intent, entities})
+      }
     )
   )
   return JSON.stringify(source, null, 2)


### PR DESCRIPTION
RASA NLU throws an error if you try to train it with data that isn't correctly formed (e.g. starts with whitespace or ends on whitespace). By using `String.trim` this can be preprocessed in the trainer and the whitespace can be removed when saving the JSON.

Using this `map` for processing entities:
```
entities.map((entity) => {
    let entityText = text.substring(entity.start, entity.end).trim()
    let entityPos = text.indexOf(entityText)
    return {
      start: entityPos,
      end: entityPos + entityText.length,
      value: entity.value,
      entity: entity.entity
    }
})
```